### PR TITLE
`--replace` -> `--replace-fail`

### DIFF
--- a/how-to-patch-a-package-source-on-nixos/alejandra4/default.nix
+++ b/how-to-patch-a-package-source-on-nixos/alejandra4/default.nix
@@ -24,7 +24,7 @@ rustPlatform.buildRustPackage rec {
 
     postPatch = ''
       substituteInPlace src/alejandra/src/builder.rs \
-          --replace "2 * build_ctx.indentation" "4 * build_ctx.indentation"
+          --replace-fail "2 * build_ctx.indentation" "4 * build_ctx.indentation"
 
       rm -r src/alejandra/tests
     '';


### PR DESCRIPTION
Thanks for the nice article :-) There are some recent discussions around depreciating `--replace` with `--replace-{fail,warn,quiet}`. https://github.com/NixOS/nixpkgs/pull/292069 guess with this change the disadvantage of not noticing when a replacement fails (whether wanted or not) compared to doing it via diff in the`patches` phase is not there anymore.